### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Función del sistema de procedencia
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/2](https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or job definition to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs a script, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No changes to the steps or other parts of the workflow are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
