### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-python-azure.yml
+++ b/.github/workflows/deploy-python-azure.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy Python App to Azure
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/1](https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way is to add the block at the root level (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For most CI/CD workflows, the minimal required permission is `contents: read`, which allows the workflow to check out code but not modify repository contents. If any step requires additional permissions (e.g., to create releases, modify issues, or deploy), those can be added as needed. In this case, since the workflow only checks out code and deploys to Azure (which uses secrets and external actions), `contents: read` is sufficient. Edit `.github/workflows/deploy-python-azure.yml` to add:

```yaml
permissions:
  contents: read
```

immediately after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
