### PR TITLE
Convert provenance script into importable module with tests

### DIFF
--- a/scripts/Python/__init__.py
+++ b/scripts/Python/__init__.py
@@ -1,0 +1,7 @@
+"""Módulos escritos en Python para el proyecto."""
+
+from .funcion_del_sistema_de_procedencia import (
+    funcion_del_sistema_de_procedencia,
+)
+
+__all__ = ["funcion_del_sistema_de_procedencia"]

--- a/scripts/Python/funcion_del_sistema_de_procedencia.py
+++ b/scripts/Python/funcion_del_sistema_de_procedencia.py
@@ -1,1 +1,15 @@
-print('Función de procedencia ejecutada correctamente')
+"""Módulo que expone la función del sistema de procedencia."""
+
+
+def funcion_del_sistema_de_procedencia() -> str:
+    """Retorna el mensaje de confirmación del sistema.
+
+    Returns:
+        str: Mensaje indicando que la función se ejecutó.
+    """
+
+    return "Función de procedencia ejecutada correctamente"
+
+
+if __name__ == "__main__":  # pragma: no cover - comportamiento CLI
+    print(funcion_del_sistema_de_procedencia())

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete que contiene scripts auxiliares."""

--- a/tests/test_funcion_del_sistema_de_procedencia.py
+++ b/tests/test_funcion_del_sistema_de_procedencia.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+# Aseguramos que el directorio raíz del proyecto esté en sys.path para poder
+# importar los módulos del paquete ``scripts`` durante la ejecución de los
+# tests.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.Python import funcion_del_sistema_de_procedencia  # noqa: E402
+
+
+def test_funcion_del_sistema_de_procedencia():
+    assert (
+        funcion_del_sistema_de_procedencia() ==
+        "Función de procedencia ejecutada correctamente"
+    )


### PR DESCRIPTION
## Summary
- Refactor `funcion_del_sistema_de_procedencia` into a reusable function and add CLI entrypoint
- Package `scripts` module and expose provenance function
- Add unit test ensuring the function returns the expected message

## Testing
- `flake8`
- `pytest`
- `bandit -r scripts`
- `python scripts/Python/funcion_del_sistema_de_procedencia.py`


------
https://chatgpt.com/codex/tasks/task_e_68ade9762cd4832483576fb7617b36f5