### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/4](https://github.com/AndresMaqueo/DevSecOps-Pro-Template/security/code-scanning/4)

To fix the problem, you should add an explicit `permissions:` block to the workflow—either at the workflow root (applies to all jobs by default) or within the specific job. The block should specify the minimum required permissions for the actions in the workflow. For the steps shown—no GitHub API write operations, just artifact uploads and report generation—`contents: read` is sufficient. Place the following after the workflow `name:` and before the `on:` block (to apply to all jobs unless overridden):  
```yaml
permissions:
  contents: read
```  
No additional methods, imports, or definitions are required, as this is a configuration change to the workflow file (.github/workflows/ci.yml).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
